### PR TITLE
Allow the root path for the blogs index page to be configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ $ npm install hexo-generator-index --save
 
 ``` yaml
 index_generator:
+  path: ''
   per_page: 10
   order_by: -date
 ```
 
+- **path**: Root path for your blogs index page. (default = '')
 - **per_page**: Posts displayed per page. (0 = disable pagination)
 - **order_by**: Posts order. (Order by date descending by default)
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -6,8 +6,9 @@ module.exports = function(locals) {
   var config = this.config;
   var posts = locals.posts.sort(config.index_generator.order_by);
   var paginationDir = config.pagination_dir || 'page';
+  var path = config.index_generator.path || '';
 
-  return pagination('', posts, {
+  return pagination(path, posts, {
     perPage: config.index_generator.per_page,
     layout: ['index', 'archive'],
     format: paginationDir + '/%d/',


### PR DESCRIPTION
This will help solve this problem.  https://github.com/hexojs/hexo/issues/1971

By setting:
```
index_generator:
  path: blog
```

and creating a `/source/index.md` you can have all blog entries in a subfolder and have a custom index page.