### PR TITLE
Clarify docs around pagination options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,15 @@ index_generator:
   order_by: -date
 ```
 
-- **path**: Root path for your blogs index page. (default = '')
-- **per_page**: Posts displayed per page. (0 = disable pagination)
-- **order_by**: Posts order. (Order by date descending by default)
+- **path**: Root path for your blog's index page. 
+  - default: ""
+- **per_page**: Posts displayed per page.
+  - default: [`config.per_page`](https://hexo.io/docs/configuration.html#Pagination) as specified in the official Hexo docs (if present), otherwise `10`
+  - `0` disables pagination
+- **order_by**: Posts order. 
+  - default: date descending
+
+`pagination_dir`
 
 ## License
 


### PR DESCRIPTION
I was having a hard time figuring out how this particular plugin worked with the configuration options in the [official hexo docs](https://hexo.io/docs/configuration.html#Pagination). After looking at the code, it appears it inherits those values (if present), so this was an attempt to merely clarify that in the README.

For example, if you have `per_page` in your hexo config, then this plugin is going to use that, i.e. 

```yaml
# _confg.yaml
# Both of these accomplish the same thing
per_page: 40       # specified in hexo docs
index_generator: # specified in hexo-generator-index docs
  per_page: 40
```