### PR TITLE
chore(node): update node engines to v6.9.0 higher

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lib": "./lib"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=6.9.0"
   },
   "repository": "hexojs/hexo-generator-index",
   "homepage": "http://hexo.io/",


### PR DESCRIPTION
Same as [hexo main repository](https://github.com/hexojs/hexo/blob/97e8f3cac2330eee9d17786196dc2e928b839c29/package.json#L79)