### PR TITLE
refactor(package): use Object.assign instead of object-assign dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 'use strict';
 
-var assign = require('object-assign');
-
-hexo.config.index_generator = assign({
+hexo.config.index_generator = Object.assign({
   per_page: typeof hexo.config.per_page === 'undefined' ? 10 : hexo.config.per_page,
   order_by: '-date'
 }, hexo.config.index_generator);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "mocha": "^2.0.1"
   },
   "dependencies": {
-    "hexo-pagination": "0.0.2",
-    "object-assign": "^4.0.1"
+    "hexo-pagination": "0.0.2"
   }
 }


### PR DESCRIPTION
## Proposal

Use Object.assign instead of object-assign package

## Reason

Node.js 4 and up can be use Object.assign() instead of object-assign npm package.
This repository is already set node engine higher than 6.9.0 .
So, it can use Object.assign() .