### PR TITLE
release: 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-index",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Index generator for Hexo.",
   "main": "index",
   "scripts": {
@@ -16,7 +16,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=10.13.0"
   },
   "repository": "hexojs/hexo-generator-index",
   "homepage": "http://hexo.io/",


### PR DESCRIPTION
#51
https://github.com/hexojs/hexo-generator-index/pull/55

Release draft
```
## Changes

- docs: mention order of 'sticky' @curbengh (#57)
- Sort by a new `sticky` parameter @stevenjoezhang (#51)
- chore: add release-drafter @YoshinoriN (#49)
- docs: pagination_dir default setting @curbengh (#41)
- docs: clarify purpose of plugin @curbengh (#40)

## Dependencies

- chore(deps-dev): bump hexo from 4.2.1 to 5.0.0 @dependabot-preview (#55)
- chore(deps-dev): bump mocha from 7.2.0 to 8.0.1 @dependabot-preview (#54)
- chore(deps-dev): bump eslint from 6.8.0 to 7.1.0 @dependabot-preview (#53)
- chore(deps-dev): bump mocha from 6.2.2 to 7.1.1 @dependabot-preview (#50)
- chore(deps-dev): bump nyc from 14.1.1 to 15.0.0 @dependabot-preview (#45)
- Bump eslint-config-hexo from 3.0.0 to 4.1.0 @dependabot-preview (#44)
- Bump hexo from 3.9.0 to 4.0.0 @dependabot-preview (#42)

```