### PR TITLE
feat: hide posts from index

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ sticky: 100
 ---
 ```
 
+The `hidden` parameter can be used to hide a post from the index page. When `hidden: true` is set, the post will not appear in the index but will still be accessible in other ways (e.g., the archive page or via a direct link).
+
+```yml
+---  
+title: Secret Post  
+date: 2024/11/11 11:11:11  
+hidden: true  
+---  
+```
+
 ## Note
 
 If your theme define a non-archive `index` layout (e.g. About Me page), this plugin would follow that layout instead and not generate an archive. In that case, use [hexo-generator-archive](https://github.com/hexojs/hexo-generator-archive) to generate an archive according to the `archive` layout.

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -4,7 +4,7 @@ const pagination = require('hexo-pagination');
 
 module.exports = function(locals) {
   const config = this.config;
-  const posts = locals.posts.sort(config.index_generator.order_by);
+  const posts = locals.posts.filter(post => !post.hidden).sort(config.index_generator.order_by);
 
   posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
 

--- a/test/index.js
+++ b/test/index.js
@@ -23,9 +23,10 @@ describe('Index generator', () => {
   before(() => hexo.init().then(() => Post.insert([
     {source: 'foo', slug: 'foo', date: 1e8, order: 0},
     {source: 'bar', slug: 'bar', date: 1e8 + 1, order: 10},
-    {source: 'baz', slug: 'baz', date: 1e8 - 1, order: 1}
+    {source: 'baz', slug: 'baz', date: 1e8 - 1, order: 1},
+    {source: 'qux', slug: 'qux', date: 1e8 - 8, order: 8, hidden: true}
   ])).then(data => {
-    posts = Post.sort('-date');
+    posts = Post.slice(0, -1).sort('-date');
     locals = hexo.locals.toObject();
   }));
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Add test cases for the changes.
- [x] Passed the CI test.

## Description

<!--  Describe your changes and why they are needed  -->

resolve #88

- Hide posts with `hidden: true` in the front matter from the index.

## Additional information

There is an issue with [the provided solution](https://github.com/hexojs/hexo-generator-index/issues/88#issuecomment-1342505722) for hiding posts after generation. Since pagination is already generated at that point, hiding multiple posts on a page can result in a significant lack of remaining posts.
