### PR TITLE
Add i18n index support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ This will generate:
 
 Each index page will contain posts in that language.
 
-To use language switch in some themes, there is some suggestion:
+To use language switch in some themes, there are some suggestions:
 1. set your `_config.yml` option `permalink` with `:lang/` prefix, like `:lang/:title/`.
-2. set your `new_post_name` option with `:lang`, like `: :lang/:title.md`, and you can use command like `hexo new post --lang zh-CN post.md` to add new post.
+2. set your `new_post_name` option with `:lang`, like `:lang/:title.md`, and you can use command like `hexo new post --lang zh-CN post.md` to add new post.
 3. organized your post with structure:
 ```
 - source

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ index_generator:
   order_by: -date
   pagination_dir: page
   layout: ["index", "archive"]
+  single_lang_index: false
 ```
 
 - **path**: Root path for your blog's index page.
@@ -39,6 +40,8 @@ index_generator:
   - e.g. set `awesome-page` makes the URL ends with `awesome-page/<page number>` for second page and beyond.
 - **layout**: custom layout.
   - defalut: `["index", "archive"]`
+- **single_lang_index**: Generate home page only the first language
+  - default: `false`
 
 ## Usage
 
@@ -60,6 +63,43 @@ title: Secret Post
 date: 2024/11/11 11:11:11  
 hidden: true  
 ---  
+```
+
+## i18n index support
+
+If you have multiple languages configured in your Hexo site, this plugin will generate an index page for each language defined in the `language` configuration.
+
+For example, if your `_config.yml` has:
+
+```yaml
+language:
+  - en
+  - zh-CN
+  - ja
+```
+
+This will generate:
+
+- `index.html` (home index page, if `single_lang_index` is `false`, it contains all language post)
+- `en/index.html` (for `en`)
+- `zh-CN/index.html` (for `zh-CN`)
+- `ja/index.html` (for `ja`)
+
+Each index page will contain posts in that language.
+
+To use language switch in some themes, there is some suggestion:
+1. set your `_config.yml` option `permalink` with `:lang/` prefix, like `:lang/:title/`.
+2. set your `new_post_name` option with `:lang`, like `: :lang/:title.md`, and you can use command like `hexo new post --lang zh-CN post.md` to add new post.
+3. organized your post with structure:
+```
+- source
+  - _posts
+    - en
+      - post.md
+    - zh-CN
+      - post.md
+    - ja
+      - post.md
 ```
 
 ## Note

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@
 hexo.config.index_generator = Object.assign({
   per_page: typeof hexo.config.per_page === 'undefined' ? 10 : hexo.config.per_page,
   order_by: '-date',
-  layout: ['index', 'archive']
+  layout: ['index', 'archive'],
+  single_lang_index: false,
 }, hexo.config.index_generator);
 
 hexo.extend.generator.register('index', require('./lib/generator'));

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ hexo.config.index_generator = Object.assign({
   per_page: typeof hexo.config.per_page === 'undefined' ? 10 : hexo.config.per_page,
   order_by: '-date',
   layout: ['index', 'archive'],
-  single_lang_index: false,
+  single_lang_index: false
 }, hexo.config.index_generator);
 
 hexo.extend.generator.register('index', require('./lib/generator'));

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -32,7 +32,7 @@ module.exports = function(locals) {
   // Generate default index page
   let indexPages = generateIndexPage(
     indexPath,
-    config.index_generator.single_lang_index ? posts.filter(post => post.lang === config.language) : posts,
+    config.index_generator.single_lang_index ? posts.filter(post => post.lang === langs[0]) : posts,
     config
   );
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -29,20 +29,22 @@ module.exports = function(locals) {
     return generateIndexPage(indexPath, posts, config);
   }
 
+  // Generate default index page
+  let indexPages = generateIndexPage(
+    indexPath,
+    posts, 
+    config
+  );
+
   // Generate index pages for each language
-  let indexPages = [].concat.apply([], 
-    langs.map(lang => generateIndexPage(
-      path.join(lang, indexPath), 
-      posts.filter(post => post.lang === lang), 
+  indexPages = [].concat(
+    indexPages, 
+    ...langs.map(lang => generateIndexPage(
+      path.join(lang, indexPath),
+      posts.filter(post => post.lang === lang),
       config
     ))
   );
 
-  // Generate default index page
-  indexPages.push(generateIndexPage(
-    indexPath,
-    posts, 
-    config
-  ));
   return indexPages;
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -2,21 +2,25 @@
 
 const pagination = require('hexo-pagination');
 
-module.exports = function(locals) {
-  const config = this.config;
-  const posts = locals.posts.filter(post => !post.hidden).sort(config.index_generator.order_by);
-
-  posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
-
+function generateIndexPage(indexPath, posts, config) {
   const paginationDir = config.index_generator.pagination_dir || config.pagination_dir || 'page';
-  const path = config.index_generator.path || '';
 
-  return pagination(path, posts, {
+  return pagination(indexPath, posts, {
     perPage: config.index_generator.per_page,
     layout: config.index_generator.layout || ['index', 'archive'],
     format: paginationDir + '/%d/',
     data: {
       __index: true
     }
-  });
+  })
+}
+
+module.exports = function(locals) {
+  const config = this.config;
+  const posts = locals.posts.filter(post => !post.hidden).sort(config.index_generator.order_by);
+
+  posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
+
+  const indexPath = config.index_generator.path || '';
+  return generateIndexPage(indexPath, posts, config);
 };

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -22,7 +22,7 @@ module.exports = function(locals) {
 
   posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
 
-  const indexPath = config.index_generator.path || '';
+  const indexPath = config.index_generator.path ?? '';
   const langs = [].concat(config.language);
 
   if (langs.length <= 1) {
@@ -32,7 +32,7 @@ module.exports = function(locals) {
   // Generate default index page
   let indexPages = generateIndexPage(
     indexPath,
-    posts, 
+    config.index_generator.single_lang_index ? posts.filter(post => post.lang === config.language) : posts,
     config
   );
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -13,7 +13,7 @@ function generateIndexPage(indexPath, posts, config) {
     data: {
       __index: true
     }
-  })
+  });
 }
 
 module.exports = function(locals) {
@@ -22,7 +22,7 @@ module.exports = function(locals) {
 
   posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
 
-  const indexPath = config.index_generator.path ?? '';
+  const indexPath = config.index_generator.path || '';
   const langs = [].concat(config.language);
 
   if (langs.length <= 1) {
@@ -38,7 +38,7 @@ module.exports = function(locals) {
 
   // Generate index pages for each language
   indexPages = [].concat(
-    indexPages, 
+    indexPages,
     ...langs.map(lang => generateIndexPage(
       path.join(lang, indexPath),
       posts.filter(post => post.lang === lang),

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const pagination = require('hexo-pagination');
+const path = require('path');
 
 function generateIndexPage(indexPath, posts, config) {
   const paginationDir = config.index_generator.pagination_dir || config.pagination_dir || 'page';
@@ -22,5 +23,26 @@ module.exports = function(locals) {
   posts.data.sort((a, b) => (b.sticky || 0) - (a.sticky || 0));
 
   const indexPath = config.index_generator.path || '';
-  return generateIndexPage(indexPath, posts, config);
+  const langs = [].concat(config.language);
+
+  if (langs.length <= 1) {
+    return generateIndexPage(indexPath, posts, config);
+  }
+
+  // Generate index pages for each language
+  let indexPages = [].concat.apply([], 
+    langs.map(lang => generateIndexPage(
+      path.join(lang, indexPath), 
+      posts.filter(post => post.lang === lang), 
+      config
+    ))
+  );
+
+  // Generate default index page
+  indexPages.push(generateIndexPage(
+    indexPath,
+    posts, 
+    config
+  ));
+  return indexPages;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -24,7 +24,7 @@ describe('Index generator', () => {
     { source: 'foo', slug: 'foo', date: 1e8, order: 0 },
     { source: 'bar', slug: 'bar', date: 1e8 + 1, order: 10 },
     { source: 'baz', slug: 'baz', date: 1e8 - 1, order: 1 },
-    { source: 'qux', slug: 'qux', date: 1e8 - 8, order: 8, hidden: true },
+    { source: 'qux', slug: 'qux', date: 1e8 - 8, order: 8, hidden: true }
   ])).then(data => {
     posts = Post.slice(0, -1).sort('-date');
     locals = hexo.locals.toObject();
@@ -167,8 +167,7 @@ describe('i18n index support', () => {
   const hexo = new Hexo(__dirname, { silent: true });
   const Post = hexo.model('Post');
   const generator = require('../lib/generator').bind(hexo);
-  let posts,
-    locals;
+  let locals;
 
   const default_index_generator = Object.freeze({
     per_page: 10,
@@ -185,7 +184,6 @@ describe('i18n index support', () => {
     { source: 'zh-CN/helloworld', slug: 'zh-CN/helloworld', date: 1e8 + 3, content: '你好，世界', lang: 'zh-CN' },
     { source: 'ja/helloworld', slug: 'ja/helloworld', date: 1e8 + 4, content: 'こんにちは、世界', lang: 'ja' }
   ])).then(data => {
-    posts = Post.slice(0, -1).sort('-date');
     locals = hexo.locals.toObject();
   }));
 
@@ -213,7 +211,7 @@ describe('i18n index support', () => {
     result[3].data.posts.length.should.eql(1);
     result[3].data.posts.eq(0).source.should.eql('ja/helloworld');
   });
-  
+
   it('single_lang_index enabled', () => {
     hexo.config.index_generator.single_lang_index = true;
 
@@ -224,6 +222,6 @@ describe('i18n index support', () => {
     // Default index page
     result[0].path.should.eql('');
     result[0].data.posts.length.should.eql(1);
-  })
+  });
 });
 

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ const should = require('chai').should(); // eslint-disable-line
 const Hexo = require('hexo');
 
 describe('Index generator', () => {
-  const hexo = new Hexo(__dirname, {silent: true});
+  const hexo = new Hexo(__dirname, { silent: true });
   const Post = hexo.model('Post');
   const generator = require('../lib/generator').bind(hexo);
   let posts,
@@ -17,14 +17,14 @@ describe('Index generator', () => {
   });
 
   beforeEach(() => {
-    hexo.config.index_generator = {...default_index_generator};
+    hexo.config.index_generator = { ...default_index_generator };
   });
 
   before(() => hexo.init().then(() => Post.insert([
-    {source: 'foo', slug: 'foo', date: 1e8, order: 0},
-    {source: 'bar', slug: 'bar', date: 1e8 + 1, order: 10},
-    {source: 'baz', slug: 'baz', date: 1e8 - 1, order: 1},
-    {source: 'qux', slug: 'qux', date: 1e8 - 8, order: 8, hidden: true}
+    { source: 'foo', slug: 'foo', date: 1e8, order: 0 },
+    { source: 'bar', slug: 'bar', date: 1e8 + 1, order: 10 },
+    { source: 'baz', slug: 'baz', date: 1e8 - 1, order: 1 },
+    { source: 'qux', slug: 'qux', date: 1e8 - 8, order: 8, hidden: true },
   ])).then(data => {
     posts = Post.slice(0, -1).sort('-date');
     locals = hexo.locals.toObject();
@@ -161,5 +161,65 @@ describe('Index generator', () => {
     });
 
   });
-
 });
+
+describe('i18n index support', () => {
+  const hexo = new Hexo(__dirname, { silent: true });
+  const Post = hexo.model('Post');
+  const generator = require('../lib/generator').bind(hexo);
+  let posts,
+    locals;
+
+  const default_index_generator = Object.freeze({
+    per_page: 10,
+    order_by: '-date'
+  });
+
+  beforeEach(() => {
+    hexo.config.index_generator = { ...default_index_generator };
+  });
+
+  before(() => hexo.init().then(() => Post.insert([
+    { source: 'en/helloworld', slug: 'en/helloworld', date: 1e8 + 2, content: 'hello world', lang: 'en' },
+    { source: 'zh-CN/helloworld', slug: 'zh-CN/helloworld', date: 1e8 + 3, content: '你好，世界', lang: 'zh-CN' },
+    { source: 'ja/helloworld', slug: 'ja/helloworld', date: 1e8 + 4, content: 'こんにちは、世界', lang: 'ja' }
+  ])).then(data => {
+    posts = Post.slice(0, -1).sort('-date');
+    locals = hexo.locals.toObject();
+  }));
+
+
+  beforeEach(async () => {
+    hexo.config.language = ['en', 'zh-CN', 'ja'];
+    await Post.insert([
+    ]);
+    hexo.locals.invalidate();
+    locals = hexo.locals.toObject();
+  });
+
+  it('generate index page for each language and default index page', () => {
+    const result = generator(locals);
+
+    result.length.should.eql(4);
+
+    // Default index page
+    result[0].path.should.eql('');
+    result[0].data.posts.length.should.eql(3);
+
+    // English index page
+    result[1].path.should.eql('en/');
+    result[1].data.posts.length.should.eql(1);
+    result[1].data.posts.eq(0).source.should.eql('en/helloworld');
+
+    // Chinese index page
+    result[2].path.should.eql('zh-CN/');
+    result[2].data.posts.length.should.eql(1);
+    result[2].data.posts.eq(0).source.should.eql('zh-CN/helloworld');
+
+    // Japanese index page
+    result[3].path.should.eql('ja/');
+    result[3].data.posts.length.should.eql(1);
+    result[3].data.posts.eq(0).source.should.eql('ja/helloworld');
+  });
+});
+

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,7 @@ describe('i18n index support', () => {
 
   beforeEach(() => {
     hexo.config.index_generator = { ...default_index_generator };
+    hexo.config.language = ['en', 'zh-CN', 'ja'];
   });
 
   before(() => hexo.init().then(() => Post.insert([
@@ -187,15 +188,6 @@ describe('i18n index support', () => {
     posts = Post.slice(0, -1).sort('-date');
     locals = hexo.locals.toObject();
   }));
-
-
-  beforeEach(async () => {
-    hexo.config.language = ['en', 'zh-CN', 'ja'];
-    await Post.insert([
-    ]);
-    hexo.locals.invalidate();
-    locals = hexo.locals.toObject();
-  });
 
   it('generate index page for each language and default index page', () => {
     const result = generator(locals);
@@ -221,5 +213,17 @@ describe('i18n index support', () => {
     result[3].data.posts.length.should.eql(1);
     result[3].data.posts.eq(0).source.should.eql('ja/helloworld');
   });
+  
+  it('single_lang_index enabled', () => {
+    hexo.config.index_generator.single_lang_index = true;
+
+    const result = generator(locals);
+
+    result.length.should.eql(4);
+
+    // Default index page
+    result[0].path.should.eql('');
+    result[0].data.posts.length.should.eql(1);
+  })
 });
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [x] Add test cases for the changes.
- [x] Passed the CI test.

## Description
I combined the plugin [xcatliu/hexo-generator-index-i18n: I18n index generator plugin for Hexo](https://github.com/xcatliu/hexo-generator-index-i18n) to this generator. The hexo-generator-index-i18n can't work with hexo-generator-index at the sometime if you want to show only default language in home page.

* Add support to generate a index for each language
* Add supoort to option home page show all languages post or not
<!--  Describe your changes and why they are needed  -->

## Additional information
