### PR TITLE
ci: drop Node.js 18,20 support and update CI to Node.js 22/24 with actions v6 and explicit permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -2,15 +2,18 @@ name: Linter
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 18
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - name: Use Node.js 22
+        uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "22"
       - name: Install Dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ["20", "22", "24"]
+        node-version: ["22", "24"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -2,18 +2,21 @@ name: Tester
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   tester:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [18, 20]
+        node-version: ["20", "22", "24"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -23,15 +26,18 @@ jobs:
         env:
           CI: true
   coverage:
+    permissions:
+      checks: write # for coverallsapp/github-action to create new checks
+      contents: read # for actions/checkout to fetch code
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18]
+        node-version: ["22"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "repository": "hexojs/hexo-generator-index",
   "homepage": "https://hexo.io/",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lib/"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "repository": "hexojs/hexo-generator-index",
   "homepage": "https://hexo.io/",


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

These changes are based on the https://github.com/hexojs/hexo repository.

- Drop Node.js 18 support and update minimum engine requirement to Node.js 20                                                                      
- Update CI test matrix to Node.js 20, 22, and 24                                                                                                  
- Bump actions/checkout and actions/setup-node from v4 to v6                                                                                       
- Add explicit permissions to GitHub Actions workflows

## Additional information

N/A