### PR TITLE
ci: add dependency-review action for vulnerability scanning

### DIFF
--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -1,0 +1,24 @@
+name: 'Dependencies Review'
+on:
+  pull_request:
+    paths:
+      - 'package.json'
+      - 'package-lock.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #6.0.1
+      - name: 'Dependencies Review'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 #4.9.0
+        with:
+          vulnerability-check: true
+          fail-on-severity: high
+          comment-summary-in-pr: always


### PR DESCRIPTION
## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

This PR adds a GitHub Actions workflow to check for vulnerabilities in dependencies when they are added or modified, and comments on the PR with the results. It detects changes to `package.json` and `lockfiles`. 

refs: https://github.com/hexojs/hexo/pull/5734

## Additional information

N/A